### PR TITLE
add callback for non-void methods of effect player

### DIFF
--- a/interfaces/offscreen_effect_player.hpp
+++ b/interfaces/offscreen_effect_player.hpp
@@ -12,6 +12,7 @@ namespace bnb::oep::interfaces
 
 using offscreen_effect_player_sptr = std::shared_ptr<bnb::oep::interfaces::offscreen_effect_player>;
 using oep_image_process_cb = std::function<void(image_processing_result_sptr)>;
+using result_bool_cb = std::function<void( bool )>;
 
 namespace bnb::oep::interfaces
 {
@@ -67,14 +68,14 @@ namespace bnb::oep::interfaces
          *
          * @example load_effect("effects/Afro")
          */
-        virtual void load_effect(const std::string& effect_path) = 0;
+        virtual void load_effect(const std::string& effect_path, result_bool_cb result_callback) = 0;
 
         /**
          * Unload effect from cache.
          *
          * @example unload_effect()
          */
-        virtual void unload_effect() = 0;
+        virtual void unload_effect(result_bool_cb result_callback) = 0;
 
         /**
          * Pause in effect player
@@ -105,7 +106,7 @@ namespace bnb::oep::interfaces
          *
          * @example call_js_method("just_bg", "{ \"recordDuration\": 15, \"rotation_vector\": true }")
          */
-        virtual void call_js_method(const std::string& method, const std::string& param) = 0;
+        virtual void call_js_method(const std::string& method, const std::string& param, result_bool_cb result_callback) = 0;
 
         /**
          * * Evaluate the `script` in effect. This method is thread safe.

--- a/offscreen_effect_player/offscreen_effect_player.cpp
+++ b/offscreen_effect_player/offscreen_effect_player.cpp
@@ -99,20 +99,23 @@ namespace bnb::oep
     }
 
     /* offscreen_effect_player::load_effect */
-    void offscreen_effect_player::load_effect(const std::string& effect_path)
+    void offscreen_effect_player::load_effect(const std::string& effect_path, result_bool_cb result_callback)
     {
-        auto task = [this, effect = effect_path]() {
+        auto task = [this, effect = effect_path, cb = result_callback]() {
             m_ort->activate_context();
-            m_ep->load_effect(effect);
+            const auto res = m_ep->load_effect(effect);
             m_ort->deactivate_context();
+            cb(res);
         };
         m_scheduler.enqueue(task);
     }
 
     /* offscreen_effect_player::unload_effect */
-    void offscreen_effect_player::unload_effect()
+    void offscreen_effect_player::unload_effect(result_bool_cb result_callback)
     {
-        load_effect("");
+        load_effect( "", [cb = result_callback](bool res) {
+            cb( res );
+        } );
     }
 
     /* offscreen_effect_player::pause */
@@ -134,12 +137,13 @@ namespace bnb::oep
     }
 
     /* offscreen_effect_player::call_js_method */
-    void offscreen_effect_player::call_js_method(const std::string& method, const std::string& param)
+    void offscreen_effect_player::call_js_method(const std::string& method, const std::string& param, result_bool_cb result_callback)
     {
-        auto task = [this, method = method, param = param]() {
+        auto task = [this, method = method, param = param, cb = result_callback]() {
             m_ort->activate_context();
-            m_ep->call_js_method(method, param);
+            const auto res = m_ep->call_js_method(method, param);
             m_ort->deactivate_context();
+            cb( res );
         };
         m_scheduler.enqueue(task);
     }

--- a/offscreen_effect_player/offscreen_effect_player.hpp
+++ b/offscreen_effect_player/offscreen_effect_player.hpp
@@ -19,9 +19,9 @@ namespace bnb::oep
 
         void surface_changed(int32_t width, int32_t height) override;
 
-        void load_effect(const std::string& effect_path) override;
+        void load_effect(const std::string& effect_path, result_bool_cb result_callback) override;
 
-        void unload_effect() override;
+        void unload_effect(result_bool_cb result_callback) override;
 
         void pause() override;
 
@@ -29,7 +29,7 @@ namespace bnb::oep
 
         void stop() override;
 
-        void call_js_method(const std::string& method, const std::string& param) override;
+        void call_js_method(const std::string& method, const std::string& param, result_bool_cb result_callback) override;
 
         void eval_js(const std::string& script, oep_eval_js_result_cb result_callback) override;
 


### PR DESCRIPTION
We need to know a result of the function execution (non-void functions: load_effect, unload_effect, call_js_method)